### PR TITLE
fix: support Windows shells and platform-correct tests

### DIFF
--- a/src/command.mjs
+++ b/src/command.mjs
@@ -2,11 +2,25 @@
  * Quote one command argument only when the shell could split or expand it.
  * Generated commands stay byte-for-byte compatible for ordinary paths while
  * paths containing spaces or shell metacharacters remain a single argument.
+ *
+ * The stored command is executed by the host's status-line runner through
+ * `sh -c` on POSIX and `spawn(cmd.exe, ['/d', '/s', '/c', command])` on
+ * Windows, so the escaping rules differ per platform:
+ * - POSIX: inside double quotes a `\`, `"`, `$` or backtick must be escaped,
+ *   or the shell rewrites the argument.
+ * - Windows: cmd.exe knows no `\` escapes and a `"` cannot occur in a real
+ *   Windows path, so the argument is wrapped unescaped. (PowerShell is not
+ *   the host shell; it shares the double-quote rule but would expand `$var`
+ *   and backticks inside them, which cmd.exe leaves literal.)
  * @param {string} value
  * @returns {string}
  */
 export function quoteCommandArg(value) {
   const text = String(value);
+  if (process.platform === 'win32') {
+    if (/^[A-Za-z0-9_@%+=:,./\\-]+$/.test(text)) return text;
+    return `"${text}"`;
+  }
   // A backslash must never reach the unquoted fast path: unquoted, a POSIX
   // shell consumes it as an escape and node receives a corrupted path.
   if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(text)) return text;

--- a/src/command.mjs
+++ b/src/command.mjs
@@ -18,7 +18,10 @@
 export function quoteCommandArg(value) {
   const text = String(value);
   if (process.platform === 'win32') {
-    if (/^[A-Za-z0-9_@%+=:,./\\-]+$/.test(text)) return text;
+    // `~` is a plain filename character for cmd.exe (no tilde expansion) and
+    // occurs in 8.3 short names like RUNNER~1, so it must reach the unquoted
+    // fast path there.
+    if (/^[A-Za-z0-9_@%+=:,./\\~-]+$/.test(text)) return text;
     return `"${text}"`;
   }
   // A backslash must never reach the unquoted fast path: unquoted, a POSIX

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -80,7 +80,14 @@ function readTextFile(filePath) {
   try {
     return { state: 'ok', text: fs.readFileSync(filePath, 'utf8') };
   } catch (err) {
-    return { state: err && err.code === 'ENOENT' ? 'missing' : 'unreadable', text: null };
+    // An unreachable UNC server surfaces on Windows as a code-less UNKNOWN
+    // error (libuv has no errno name for the network failure). The path is
+    // not a broken local file but simply unreachable, so it is classified
+    // like absence instead of raising a false "cannot be read" warning.
+    return {
+      state: !err || !err.code || err.code === 'ENOENT' ? 'missing' : 'unreadable',
+      text: null,
+    };
   }
 }
 

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -80,12 +80,15 @@ function readTextFile(filePath) {
   try {
     return { state: 'ok', text: fs.readFileSync(filePath, 'utf8') };
   } catch (err) {
-    // An unreachable UNC server surfaces on Windows as a code-less UNKNOWN
-    // error (libuv has no errno name for the network failure). The path is
-    // not a broken local file but simply unreachable, so it is classified
+    // An unreachable UNC server surfaces on Windows as libuv's UNKNOWN error
+    // (observed on a real CI run: statSync reports ENOENT for the same path
+    // while the open fails without a network-specific errno name). The path
+    // is not a broken local file but simply unreachable, so it is classified
     // like absence instead of raising a false "cannot be read" warning.
     return {
-      state: !err || !err.code || err.code === 'ENOENT' ? 'missing' : 'unreadable',
+      state: !err || !err.code || err.code === 'ENOENT' || err.code === 'UNKNOWN'
+        ? 'missing'
+        : 'unreadable',
       text: null,
     };
   }

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -10,18 +10,25 @@ import { nodeCommand, quoteCommandArg } from '../src/command.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+// Windows hosts run the stored command through their own shell, so the
+// POSIX-escaping expectations below skip there and Windows semantics stay
+// with the honest cmd.exe/PowerShell probe at the bottom of this file.
+const POSIX_SKIP = process.platform === 'win32'
+  ? 'drives /bin/sh and POSIX path semantics; Windows needs its own verified run'
+  : false;
+
 test('ordinary script paths keep the historical command format', () => {
   assert.equal(nodeCommand('/Users/test/kimi-code-hud/bin/kimi-hud.mjs'),
     'node /Users/test/kimi-code-hud/bin/kimi-hud.mjs');
 });
 
-test('paths with spaces and shell metacharacters stay one argument', () => {
+test('paths with spaces and shell metacharacters stay one argument', { skip: POSIX_SKIP }, () => {
   assert.equal(nodeCommand('/Users/Test User/hud$1.mjs'),
     'node "/Users/Test User/hud\\$1.mjs"');
   assert.equal(quoteCommandArg('plain/path'), 'plain/path');
 });
 
-test('backslash paths are quoted so POSIX shells do not consume the escape', () => {
+test('backslash paths are quoted so POSIX shells do not consume the escape', { skip: POSIX_SKIP }, () => {
   // Unquoted, sh reads back\slash as backslash; the doubled form inside
   // double quotes survives every POSIX shell byte-for-byte.
   assert.equal(quoteCommandArg('back\\slash/kimi-hud.mjs'), '"back\\\\slash/kimi-hud.mjs"');
@@ -41,12 +48,7 @@ const POSIX_SHELLS = ['/bin/sh', '/bin/bash', '/bin/zsh'];
 
 // Everything below is POSIX-only: on Windows /bin/sh does not exist and
 // several hostile directory names (pipe, wildcard, quote, newline) are
-// illegal filenames. Those cases skip there instead of failing CI, and
-// Windows execution stays covered by the honest cmd.exe/PowerShell probe
-// at the bottom of this file — the only place it can ever be verified.
-const POSIX_SKIP = process.platform === 'win32'
-  ? 'drives /bin/sh and POSIX path semantics; Windows needs its own verified run'
-  : false;
+// illegal filenames. Those cases skip there instead of failing CI.
 
 // A stub "entry point" that records the argv it received, so the test can
 // prove the shell handed the script path through as a single argument.
@@ -161,27 +163,54 @@ test('Windows cmd.exe and PowerShell execution of the generated command', {
   skip: process.platform !== 'win32'
     && 'cmd.exe/PowerShell quoting cannot be verified on this POSIX host; needs a real Windows run (H05, unverified)',
 }, () => {
-  // quoteCommandArg emits POSIX double-quote escaping. cmd.exe knows no `\`
-  // escapes and expands %VARS% inside double quotes, so this body is expected
-  // to expose mismatches when it finally runs on Windows — that is its job.
-  // Until a Windows host executes it, Windows quoting stays unverified and is
-  // NOT claimed correct anywhere.
+  // The host runs the stored command with spawn(ComSpec, ['/d', '/s', '/c',
+  // command]). spawn re-quotes the whole command for the cmd.exe command
+  // line and cmd /s strips only that outer pair, so the child's argv parser
+  // sees every stored `"` as an escaped literal quote that cannot open a
+  // quoted section. Two consequences, verified here for real: a spaceless
+  // install path (quote-free command) reaches node byte-exact, while a path
+  // with spaces splits and never arrives as one argument.
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-hud-win-'));
-  const record = path.join(root, 'argv-records.jsonl');
-  const script = path.join(root, 'with space', 'kimi-hud.mjs');
-  fs.mkdirSync(path.dirname(script), { recursive: true });
-  fs.writeFileSync(script, STUB_SCRIPT);
-  const env = { PATH: process.env.PATH, STUB_RECORD: record };
-  const cmd = spawnSync('cmd.exe', ['/d', '/s', '/c', nodeCommand(script)], {
-    env, encoding: 'utf8',
+
+  const writeScript = (dir) => {
+    const record = path.join(root, `${dir.replace(/[^\w-]+/g, '-')}.argv.jsonl`);
+    const script = path.join(root, dir, 'kimi-hud.mjs');
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.writeFileSync(script, STUB_SCRIPT);
+    return { record, script };
+  };
+
+  // Spaceless: the quote-free generated command must survive the seam.
+  const plain = writeScript('plain-bin');
+  const cmd = spawnSync('cmd.exe', ['/d', '/s', '/c', nodeCommand(plain.script)], {
+    env: { ...process.env, STUB_RECORD: plain.record },
+    encoding: 'utf8',
   });
   assert.equal(cmd.status, 0, cmd.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(plain.record, 'utf8')), [plain.script]);
+
+  // With spaces: the quoted command cannot survive the spawn→cmd.exe seam,
+  // so the script path splits and the stub never runs. Pinning that
+  // degradation instead of skipping keeps the seam honest: if the host or
+  // node ever changes how the command reaches the child, this flags it.
+  const spaced = writeScript('with space');
+  const cmdSpaced = spawnSync('cmd.exe', ['/d', '/s', '/c', nodeCommand(spaced.script)], {
+    env: { ...process.env, STUB_RECORD: spaced.record },
+    encoding: 'utf8',
+  });
+  assert.notEqual(cmdSpaced.status, 0, cmdSpaced.stderr);
+  assert.equal(fs.existsSync(spaced.record), false, 'the spaced path must not arrive as one argument');
+
+  // PowerShell is not the host shell, but its argv parsing keeps the outer
+  // quotes, so the same quoted command does deliver one exact argument.
   const powershell = spawnSync(
     'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', nodeCommand(script)],
-    { env, encoding: 'utf8' },
+    ['-NoProfile', '-NonInteractive', '-Command', nodeCommand(spaced.script)],
+    { env: { ...process.env, STUB_RECORD: spaced.record }, encoding: 'utf8' },
   );
   assert.equal(powershell.status, 0, powershell.stderr);
-  const last = fs.readFileSync(record, 'utf8').trimEnd().split('\n').at(-1);
-  assert.deepEqual(JSON.parse(last), [script]);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(spaced.record, 'utf8').trimEnd().split('\n').at(-1)),
+    [spaced.script],
+  );
 });

--- a/test/disable-self-clean.test.mjs
+++ b/test/disable-self-clean.test.mjs
@@ -19,7 +19,10 @@ function setup(installedJson) {
   fs.writeFileSync(path.join(home, 'plugins', 'installed.json'), installedJson);
   const toml = path.join(home, 'tui.toml');
   const script = path.join(managed, 'bin', 'kimi-hud.mjs');
-  fs.writeFileSync(toml, `[status_line]\ncommand = "node ${script}"\n`);
+  // Mirror tomlEscape: a backslash path written raw into a TOML basic string
+  // is invalid TOML, and the HUD fails closed on syntax it cannot parse.
+  const command = `node ${script}`.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  fs.writeFileSync(toml, `[status_line]\ncommand = "${command}"\n`);
   return { home, toml, script };
 }
 

--- a/test/doctor.test.mjs
+++ b/test/doctor.test.mjs
@@ -515,7 +515,9 @@ test('shareable output masks personal paths; local output shows them', () => {
   const report = collectDoctorReport({ paths: env.paths, env: {}, scriptPath: SCRIPT, now: NOW });
   const local = formatDoctorReport(report);
   const share = formatDoctorReport(report, { shareable: true });
-  assert.match(local, new RegExp(`path: ${env.paths.quotaCachePath}`));
+  // includes, not a RegExp: a Windows path's backslashes would be consumed
+  // as regex escapes and the assertion would never match its own output.
+  assert.ok(local.includes(`path: ${env.paths.quotaCachePath}`));
   assert.equal(share.includes(env.root), false, 'shareable output must not contain the tmp root');
   // Paths under the known roots are rewritten to logical labels.
   assert.match(share, /path: \$KIMI_HUD_HOME[\\/]quota\.json/);
@@ -581,7 +583,9 @@ test('bin --doctor --share masks a UNC kimi home (user repro)', () => {
     },
     encoding: 'utf8',
   });
-  assert.equal(result.status, 0, result.stderr);
+  // The report body on failure is synthetic (a fake UNC server) and shows
+  // exactly which doctor check classified the unreachable home as a warning.
+  assert.equal(result.status, 0, `${result.stderr}\n--- stdout ---\n${result.stdout}`);
   assert.equal(result.stdout.includes('private-server'), false);
   assert.equal(result.stdout.includes('PrivateCustomer'), false);
   assert.match(result.stdout, /path: \$KIMI_CODE_HOME/);

--- a/test/git.test.mjs
+++ b/test/git.test.mjs
@@ -170,7 +170,11 @@ test('independent readers share branch and dirty results through the disk cache'
   assert.match(key, /^[a-f0-9]{64}$/);
   assert.doesNotMatch(rawCache, new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.deepEqual(Object.keys(parsedCache.entries[key]).sort(), ['branch', 'checkedAt', 'dirty']);
-  assert.equal(fs.statSync(cachePath).mode & 0o777, 0o600);
+  // Windows models no POSIX permission bits and stats every writable file as
+  // 0o666, so the 0o600 evidence is only readable on POSIX.
+  if (process.platform !== 'win32') {
+    assert.equal(fs.statSync(cachePath).mode & 0o777, 0o600);
+  }
 
   now += 14_999;
   const secondReader = createGitStatusReader({
@@ -631,9 +635,16 @@ test('a symlink cachePath is atomically replaced without touching its target', (
     { branch: 'secured', dirty: false },
   );
   assert.equal(fs.readFileSync(targetPath, 'utf8'), 'target-content');
-  assert.equal(fs.statSync(targetPath).mode & 0o777, 0o644);
+  // Windows stats every writable file as 0o666 regardless of the chmod, so
+  // the untouched-mode evidence is only readable on POSIX; the byte-identical
+  // content above carries the not-recreated proof on every platform.
+  if (process.platform !== 'win32') {
+    assert.equal(fs.statSync(targetPath).mode & 0o777, 0o644);
+  }
   const cacheStat = fs.lstatSync(cachePath);
   assert.equal(cacheStat.isSymbolicLink(), false);
   assert.equal(cacheStat.isFile(), true);
-  assert.equal(cacheStat.mode & 0o777, 0o600);
+  if (process.platform !== 'win32') {
+    assert.equal(cacheStat.mode & 0o777, 0o600);
+  }
 });

--- a/test/sync-status-line.test.mjs
+++ b/test/sync-status-line.test.mjs
@@ -27,11 +27,30 @@ function runHook(env) {
   });
 }
 
+// Byte-exact expectation for the written [status_line] command line, derived
+// from the documented contract rather than by calling src/command.mjs: the
+// script path stays unquoted unless the platform shell requires quoting, and
+// the command is stored as a TOML basic string with backslashes and inner
+// quotes escaped. POSIX additionally escapes `\`, `"`, `$` and backtick
+// inside the quotes (none of which occur in these fixture paths); the
+// Windows shell knows no `\` escapes and a `"` cannot occur in a real
+// Windows path, so the quotes wrap the path unescaped there.
+function expectedStatusLine(pluginRoot) {
+  const script = path.join(pluginRoot, 'bin', 'kimi-hud.mjs');
+  const safe = /^[A-Za-z0-9_@%+=:,./\\-]+$/;
+  const posixSafe = /^[A-Za-z0-9_@%+=:,./-]+$/;
+  const needsQuotes = process.platform === 'win32'
+    ? !safe.test(script)
+    : !posixSafe.test(script);
+  const command = needsQuotes ? `"${script}"` : script;
+  return `command = "node ${command.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 test('creates tui.toml pointing at the managed copy', () => {
   const { home, pluginRoot, toml } = setup();
   runHook({ KIMI_CODE_HOME: home, KIMI_PLUGIN_ROOT: pluginRoot });
   const out = fs.readFileSync(toml, 'utf8');
-  assert.equal(out, `[status_line]\ncommand = "node ${pluginRoot}/bin/kimi-hud.mjs"\n`);
+  assert.equal(out, `[status_line]\n${expectedStatusLine(pluginRoot)}\n`);
 });
 
 test('session start sweeps stale HUD temporaries and expired session state', () => {
@@ -62,7 +81,7 @@ test('rewrites a previous kimi-hud command to the managed copy', () => {
   fs.writeFileSync(toml, '[status_line]\ncommand = "node /Users/test/kimi-code-hud/bin/kimi-hud.mjs"\n');
   runHook({ KIMI_CODE_HOME: home, KIMI_PLUGIN_ROOT: pluginRoot });
   const out = fs.readFileSync(toml, 'utf8');
-  assert.equal(out, `[status_line]\ncommand = "node ${pluginRoot}/bin/kimi-hud.mjs"\n`);
+  assert.equal(out, `[status_line]\n${expectedStatusLine(pluginRoot)}\n`);
 });
 
 test('installs even when another section has its own command key', () => {
@@ -74,7 +93,7 @@ test('installs even when another section has its own command key', () => {
   const out = fs.readFileSync(toml, 'utf8');
   assert.equal(
     out,
-    `[editor]\ncommand = "" # Empty uses $VISUAL / $EDITOR\n\n[status_line]\ncommand = "node ${pluginRoot}/bin/kimi-hud.mjs"\n`,
+    `[editor]\ncommand = "" # Empty uses $VISUAL / $EDITOR\n\n[status_line]\n${expectedStatusLine(pluginRoot)}\n`,
   );
 });
 
@@ -83,7 +102,7 @@ test('rewrites a previous kimi-hud command that carries trailing arguments', () 
   fs.writeFileSync(toml, '[status_line]\ncommand = "node /a/bin/kimi-hud.mjs --layout compact"\n');
   runHook({ KIMI_CODE_HOME: home, KIMI_PLUGIN_ROOT: pluginRoot });
   const out = fs.readFileSync(toml, 'utf8');
-  assert.equal(out, `[status_line]\ncommand = "node ${pluginRoot}/bin/kimi-hud.mjs"\n`);
+  assert.equal(out, `[status_line]\n${expectedStatusLine(pluginRoot)}\n`);
 });
 
 test('leaves a foreign command with trailing arguments untouched', () => {
@@ -132,7 +151,7 @@ test('quotes a managed-copy path containing spaces', () => {
   runHook({ KIMI_CODE_HOME: home, KIMI_PLUGIN_ROOT: pluginRoot });
   assert.equal(
     fs.readFileSync(toml, 'utf8'),
-    `[status_line]\ncommand = "node \\"${pluginRoot}/bin/kimi-hud.mjs\\""\n`,
+    `[status_line]\n${expectedStatusLine(pluginRoot)}\n`,
   );
 });
 
@@ -143,7 +162,7 @@ test('preserves other sections and status_line keys', () => {
   const out = fs.readFileSync(toml, 'utf8');
   assert.equal(
     out,
-    `[theme]\nname = "dark"\n\n[status_line]\ncommand = "node ${pluginRoot}/bin/kimi-hud.mjs"\nitems = ["model"]\n`,
+    `[theme]\nname = "dark"\n\n[status_line]\n${expectedStatusLine(pluginRoot)}\nitems = ["model"]\n`,
   );
 });
 

--- a/test/sync-status-line.test.mjs
+++ b/test/sync-status-line.test.mjs
@@ -37,7 +37,9 @@ function runHook(env) {
 // Windows path, so the quotes wrap the path unescaped there.
 function expectedStatusLine(pluginRoot) {
   const script = path.join(pluginRoot, 'bin', 'kimi-hud.mjs');
-  const safe = /^[A-Za-z0-9_@%+=:,./\\-]+$/;
+  // Mirrors src/command.mjs's per-platform unquoted fast path: the Windows
+  // set adds the native separator and 8.3 short names' `~`.
+  const safe = /^[A-Za-z0-9_@%+=:,./\\~-]+$/;
   const posixSafe = /^[A-Za-z0-9_@%+=:,./-]+$/;
   const needsQuotes = process.platform === 'win32'
     ? !safe.test(script)


### PR DESCRIPTION
## User-visible change

HUD's generated status-line commands now work under Windows cmd.exe/PowerShell: `quoteCommandArg` gains a win32 rule set (bare double quotes, no POSIX backslash escaping), fixing garbled paths on Windows. POSIX output is byte-for-byte unchanged. Known upstream limit documented in tests: with the host's current `cmd /d /s /c` spawn seam, install paths containing spaces cannot survive quoting on Windows; the host silently falls back to the built-in footer there.

Also fixes doctor exit code on unreachable UNC paths (libuv `UNKNOWN` is now classified as 'missing', not a warning).

## Test fixes

Real-Windows CI exposed POSIX assumptions in the new dynamic suites: TOML fixtures now escape backslashes, path assertions no longer feed unescaped paths into RegExp, POSIX mode-bit assertions are platform-gated, and status-line expectations mirror the quoting + TOML-escaping contract via an independent helper.

## Verification

- `npm test` green on macOS (572 pass / 0 fail / 1 platform skip) after every change
- GitHub Actions run 34126906651 on this branch: all 6 jobs green, including node-test (24, windows-latest) — 13 failures iterated to 0 over three runs
- `node --check` and `git diff --check` clean on all touched files